### PR TITLE
Add deterministic pretraining skeletons

### DIFF
--- a/configs/pretraining/chemberta2_mlm.json
+++ b/configs/pretraining/chemberta2_mlm.json
@@ -26,6 +26,39 @@
     "fp16": true
   },
   "comparison": {
+    "shared_split": "same rows and split seeds as property_prediction_multitask",
+    "runs": [
+      {
+        "name": "random_weight_unimol_features",
+        "training_mode": "random initialization control",
+        "downstream_protocol": "extract embeddings once, train identical deterministic/tabular regressor on issue #5 splits",
+        "artifact_policy": "store feature tensors and checkpoints outside git with checksum references only"
+      },
+      {
+        "name": "frozen_chemberta2_embeddings",
+        "training_mode": "frozen pretrained ChemBERTa2 encoder",
+        "downstream_protocol": "fit the same regression head and metrics as Uni-Mol/MolCLR on identical rows",
+        "artifact_policy": "commit config, metric table, dataset manifest, and external artifact URI/checksum"
+      },
+      {
+        "name": "finetuned_chemberta2_regression_head",
+        "training_mode": "ChemBERTa2 fine-tuning for downstream regression",
+        "downstream_protocol": "report MAE/RMSE/R2 per split seed with mean and standard deviation",
+        "artifact_policy": "keep weights, optimizer state, and trainer logs out of git"
+      },
+      {
+        "name": "unimol_finetune",
+        "training_mode": "existing Uni-Mol fine-tuning workflow",
+        "downstream_protocol": "use the same target columns, split seeds, and metric definitions",
+        "artifact_policy": "reference checkpoints externally; commit only reviewed summaries"
+      },
+      {
+        "name": "molclr_finetune",
+        "training_mode": "existing MolCLR fine-tuning workflow",
+        "downstream_protocol": "use the same target columns, split seeds, and metric definitions",
+        "artifact_policy": "reference checkpoints externally; commit only reviewed summaries"
+      }
+    ],
     "baselines": [
       "random_weight_unimol_features",
       "frozen_chemberta2_embeddings",

--- a/docs/pretraining_workflows.md
+++ b/docs/pretraining_workflows.md
@@ -14,6 +14,8 @@ ChemBERTa2 experiments should be recorded as masked-language-modeling pretrainin
 
 Config stub: `configs/pretraining/chemberta2_mlm.json`.
 
+The config now includes a comparison matrix for random-weight Uni-Mol, frozen ChemBERTa2 embeddings, fine-tuned ChemBERTa2, Uni-Mol fine-tuning, and MolCLR fine-tuning. All runs must use the same downstream rows, split seeds, metrics, and artifact policy before their numbers are compared.
+
 Example command shape:
 
 ```bash
@@ -33,6 +35,8 @@ The exact command may differ by the installed `transformers` version; preserve t
 The first supported property task is the existing `TARGET` residual for delta PCE in `train/train.csv`. Bandgap and stability are defined as schema stubs until public or private columns are added.
 
 Config stub: `configs/pretraining/property_prediction_multitask.json`.
+
+Lightweight scaffold: `perovskite_pretrain.property_prediction` provides dependency-free CSV loading, deterministic SMILES features, a k-nearest-neighbor regressor, and simple feature-importance scores. This is for smoke tests, candidate screening, and schema validation only; it does not satisfy the trained MAE thresholds without calibrated data and model training.
 
 Recommended evaluation sequence:
 
@@ -64,6 +68,8 @@ Generation work should start as a screened candidate pipeline before training la
 6. Commit only reviewed candidate schemas, small top-k tables, and configs.
 
 Config stub: `configs/pretraining/molecule_generation_vae.json`.
+
+Lightweight scaffold: `perovskite_pretrain.generation` provides deterministic substituent-based candidate generation plus validity, novelty, duplicate, filter-note, and predictor-score evaluation. It is a generation/evaluation skeleton for issue #6, not a trained VAE, RL optimizer, or synthetic-accessibility model.
 
 Acceptance metrics should be reported only when the predictor is calibrated for the target property. Until then, record validity, novelty, duplicate rate, and filter reasons.
 

--- a/perovskite_pretrain/__init__.py
+++ b/perovskite_pretrain/__init__.py
@@ -1,0 +1,25 @@
+"""Lightweight deterministic utilities for pretraining workflow tests."""
+
+from perovskite_pretrain.generation import (
+    Candidate,
+    CandidateGenerator,
+    EvaluatedCandidate,
+    evaluate_candidates,
+    summarize_screening,
+)
+from perovskite_pretrain.property_prediction import (
+    DeterministicPropertyPredictor,
+    PropertyRow,
+    load_property_rows,
+)
+
+__all__ = [
+    "Candidate",
+    "CandidateGenerator",
+    "DeterministicPropertyPredictor",
+    "EvaluatedCandidate",
+    "PropertyRow",
+    "evaluate_candidates",
+    "load_property_rows",
+    "summarize_screening",
+]

--- a/perovskite_pretrain/generation.py
+++ b/perovskite_pretrain/generation.py
@@ -1,0 +1,156 @@
+"""Deterministic molecular-generation and screening scaffolds."""
+
+from __future__ import annotations
+
+import re
+from dataclasses import dataclass, field
+from typing import Iterable
+
+from perovskite_pretrain.property_prediction import DeterministicPropertyPredictor
+
+
+ATOM_PATTERN = re.compile(r"Cl|Br|[A-Z][a-z]?|[cnops]")
+BALANCED_PAIRS = {"(": ")", "[": "]"}
+
+
+@dataclass(frozen=True)
+class Candidate:
+    smiles: str
+    source_seed_smiles: str
+    generation_method: str = "deterministic_substituent_append"
+
+
+@dataclass(frozen=True)
+class EvaluatedCandidate:
+    smiles: str
+    source_seed_smiles: str
+    generation_method: str
+    valid: bool
+    novel: bool
+    duplicate: bool
+    predictions: dict[str, float] = field(default_factory=dict)
+    filter_notes: tuple[str, ...] = ()
+
+
+class CandidateGenerator:
+    """Generate small deterministic candidate sets from seed SMILES."""
+
+    def __init__(self, seed: int = 0, substituents: Iterable[str] | None = None):
+        self.seed = seed
+        self.substituents = tuple(substituents or ("N", "O", "F", "Cl", "C#N"))
+
+    def generate(self, seed_smiles: Iterable[str], n_per_seed: int = 5) -> list[Candidate]:
+        if n_per_seed <= 0:
+            raise ValueError("n_per_seed must be positive")
+
+        candidates: list[Candidate] = []
+        seen: set[str] = set()
+        for smiles in seed_smiles:
+            stripped = smiles.strip()
+            if not stripped:
+                continue
+            for substituent in self.substituents[:n_per_seed]:
+                candidate_smiles = f"{stripped}{substituent}"
+                if candidate_smiles in seen:
+                    continue
+                seen.add(candidate_smiles)
+                candidates.append(
+                    Candidate(smiles=candidate_smiles, source_seed_smiles=stripped)
+                )
+        return candidates
+
+
+def validate_smiles_syntax(
+    smiles: str, allowed_atoms: set[str] | None = None
+) -> tuple[bool, tuple[str, ...]]:
+    """Perform dependency-free structural checks before optional RDKit screening."""
+
+    notes: list[str] = []
+    if not smiles:
+        notes.append("empty_smiles")
+
+    for open_char, close_char in BALANCED_PAIRS.items():
+        if smiles.count(open_char) != smiles.count(close_char):
+            notes.append(f"unbalanced_{open_char}{close_char}")
+
+    atoms = [match.group(0).capitalize() for match in ATOM_PATTERN.finditer(smiles)]
+    if not atoms:
+        notes.append("no_atoms_detected")
+
+    if allowed_atoms is not None:
+        disallowed = sorted({atom for atom in atoms if atom not in allowed_atoms})
+        if disallowed:
+            notes.append("disallowed_atoms:" + ",".join(disallowed))
+
+    return not notes, tuple(notes)
+
+
+def evaluate_candidates(
+    candidates: Iterable[Candidate],
+    training_smiles: Iterable[str],
+    predictor: DeterministicPropertyPredictor | None = None,
+    allowed_atoms: set[str] | None = None,
+) -> list[EvaluatedCandidate]:
+    """Validate, de-duplicate, check novelty, and optionally score candidates."""
+
+    training_set = {smiles.strip() for smiles in training_smiles if smiles.strip()}
+    seen: set[str] = set()
+    evaluated: list[EvaluatedCandidate] = []
+
+    for candidate in candidates:
+        duplicate = candidate.smiles in seen
+        seen.add(candidate.smiles)
+        valid, notes = validate_smiles_syntax(candidate.smiles, allowed_atoms=allowed_atoms)
+        novel = candidate.smiles not in training_set
+        all_notes = list(notes)
+        if duplicate:
+            all_notes.append("duplicate_candidate")
+        if not novel:
+            all_notes.append("seen_in_training")
+
+        predictions: dict[str, float] = {}
+        if predictor is not None and valid:
+            predictions = predictor.predict_smiles(candidate.smiles)
+
+        evaluated.append(
+            EvaluatedCandidate(
+                smiles=candidate.smiles,
+                source_seed_smiles=candidate.source_seed_smiles,
+                generation_method=candidate.generation_method,
+                valid=valid,
+                novel=novel,
+                duplicate=duplicate,
+                predictions=predictions,
+                filter_notes=tuple(all_notes),
+            )
+        )
+
+    return evaluated
+
+
+def summarize_screening(evaluated: Iterable[EvaluatedCandidate]) -> dict[str, float | int]:
+    rows = list(evaluated)
+    total = len(rows)
+    if total == 0:
+        return {
+            "total": 0,
+            "valid": 0,
+            "novel": 0,
+            "duplicates": 0,
+            "valid_fraction": 0.0,
+            "novel_fraction": 0.0,
+            "duplicate_fraction": 0.0,
+        }
+
+    valid = sum(row.valid for row in rows)
+    novel = sum(row.novel for row in rows)
+    duplicates = sum(row.duplicate for row in rows)
+    return {
+        "total": total,
+        "valid": valid,
+        "novel": novel,
+        "duplicates": duplicates,
+        "valid_fraction": valid / total,
+        "novel_fraction": novel / total,
+        "duplicate_fraction": duplicates / total,
+    }

--- a/perovskite_pretrain/property_prediction.py
+++ b/perovskite_pretrain/property_prediction.py
@@ -1,0 +1,156 @@
+"""Small deterministic property-prediction helpers.
+
+These utilities provide a testable scaffold for issues #5 and #6 without
+depending on heavy ML frameworks or trained artifacts. They are intentionally
+simple and should be replaced by calibrated model adapters for publication
+metrics.
+"""
+
+from __future__ import annotations
+
+import csv
+import math
+import re
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Iterable, Mapping
+
+
+ATOM_PATTERN = re.compile(r"Cl|Br|[A-Z][a-z]?|[cnops]")
+DEFAULT_TARGET_COLUMNS = {
+    "delta_pce": "TARGET",
+    "bandgap": "BANDGAP_EV",
+    "stability_t80": "T80_HOURS",
+}
+
+
+@dataclass(frozen=True)
+class PropertyRow:
+    """One molecule with whichever property labels are available."""
+
+    smiles: str
+    targets: dict[str, float]
+
+
+def load_property_rows(
+    csv_path: str | Path,
+    smiles_column: str = "SMILES",
+    target_columns: Mapping[str, str] | None = None,
+) -> list[PropertyRow]:
+    """Load property rows while skipping missing target values per task."""
+
+    path = Path(csv_path)
+    columns = dict(target_columns or DEFAULT_TARGET_COLUMNS)
+    rows: list[PropertyRow] = []
+
+    with path.open(newline="", encoding="utf-8-sig") as handle:
+        reader = csv.DictReader(handle)
+        for raw in reader:
+            smiles = (raw.get(smiles_column) or "").strip()
+            if not smiles:
+                continue
+
+            targets: dict[str, float] = {}
+            for task_name, column_name in columns.items():
+                value = (raw.get(column_name) or "").strip()
+                if value:
+                    targets[task_name] = float(value)
+            if targets:
+                rows.append(PropertyRow(smiles=smiles, targets=targets))
+
+    return rows
+
+
+def smiles_features(smiles: str) -> dict[str, float]:
+    """Return compact deterministic features from a SMILES string."""
+
+    atoms = [match.group(0).capitalize() for match in ATOM_PATTERN.finditer(smiles)]
+    features: dict[str, float] = {
+        "length": float(len(smiles)),
+        "branch_count": float(smiles.count("(")),
+        "ring_digit_count": float(sum(char.isdigit() for char in smiles)),
+        "double_bond_count": float(smiles.count("=")),
+        "triple_bond_count": float(smiles.count("#")),
+        "aromatic_count": float(sum(char in "cnops" for char in smiles)),
+    }
+
+    for atom in atoms:
+        features[f"atom_{atom}"] = features.get(f"atom_{atom}", 0.0) + 1.0
+    return features
+
+
+def _distance(left: Mapping[str, float], right: Mapping[str, float]) -> float:
+    keys = set(left) | set(right)
+    return math.sqrt(sum((left.get(key, 0.0) - right.get(key, 0.0)) ** 2 for key in keys))
+
+
+class DeterministicPropertyPredictor:
+    """Deterministic k-nearest-neighbor regressor for scaffold workflows."""
+
+    def __init__(self, k_neighbors: int = 3):
+        if k_neighbors <= 0:
+            raise ValueError("k_neighbors must be positive")
+        self.k_neighbors = k_neighbors
+        self._rows: list[PropertyRow] = []
+        self._features: list[dict[str, float]] = []
+
+    @property
+    def tasks(self) -> list[str]:
+        task_names = {task for row in self._rows for task in row.targets}
+        return sorted(task_names)
+
+    def fit(self, rows: Iterable[PropertyRow]) -> "DeterministicPropertyPredictor":
+        self._rows = list(rows)
+        if not self._rows:
+            raise ValueError("At least one labeled row is required")
+        self._features = [smiles_features(row.smiles) for row in self._rows]
+        return self
+
+    def fit_smiles(
+        self, rows: Iterable[tuple[str, Mapping[str, float]]]
+    ) -> "DeterministicPropertyPredictor":
+        return self.fit(PropertyRow(smiles, dict(targets)) for smiles, targets in rows)
+
+    def predict_smiles(self, smiles: str) -> dict[str, float]:
+        if not self._rows:
+            raise ValueError("Predictor must be fitted before prediction")
+
+        query_features = smiles_features(smiles)
+        predictions: dict[str, float] = {}
+        for task in self.tasks:
+            neighbors = []
+            for row, features in zip(self._rows, self._features, strict=True):
+                if task in row.targets:
+                    neighbors.append((_distance(query_features, features), row.targets[task]))
+            neighbors.sort(key=lambda item: (item[0], item[1]))
+            selected = neighbors[: self.k_neighbors]
+            weights = [1.0 / (distance + 1.0) for distance, _ in selected]
+            total_weight = sum(weights)
+            predictions[task] = sum(
+                weight * value for weight, (_, value) in zip(weights, selected, strict=True)
+            ) / total_weight
+
+        return predictions
+
+    def feature_importance(self, task: str) -> dict[str, float]:
+        """Estimate task sensitivity via absolute feature-target covariance."""
+
+        labeled = [
+            (features, row.targets[task])
+            for row, features in zip(self._rows, self._features, strict=True)
+            if task in row.targets
+        ]
+        if not labeled:
+            raise ValueError(f"No fitted rows have target {task!r}")
+
+        mean_target = sum(target for _, target in labeled) / len(labeled)
+        keys = sorted({key for features, _ in labeled for key in features})
+        scores = {}
+        for key in keys:
+            mean_feature = sum(features.get(key, 0.0) for features, _ in labeled) / len(labeled)
+            covariance = sum(
+                (features.get(key, 0.0) - mean_feature) * (target - mean_target)
+                for features, target in labeled
+            )
+            scores[key] = abs(covariance) / len(labeled)
+        return dict(sorted(scores.items(), key=lambda item: (-item[1], item[0])))

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,3 +1,4 @@
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 python_files = ["test_*.py"]
+pythonpath = ["."]

--- a/tests/test_deterministic_skeletons.py
+++ b/tests/test_deterministic_skeletons.py
@@ -1,0 +1,106 @@
+import csv
+import json
+from pathlib import Path
+
+from perovskite_pretrain.generation import (
+    CandidateGenerator,
+    evaluate_candidates,
+    summarize_screening,
+)
+from perovskite_pretrain.property_prediction import (
+    DeterministicPropertyPredictor,
+    load_property_rows,
+)
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def write_csv(path, rows):
+    with path.open("w", newline="", encoding="utf-8") as handle:
+        writer = csv.DictWriter(handle, fieldnames=rows[0].keys())
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def test_property_rows_load_only_available_targets(tmp_path):
+    data_path = tmp_path / "properties.csv"
+    write_csv(
+        data_path,
+        [
+            {"SMILES": "CCO", "TARGET": "0.5", "BANDGAP_EV": "", "T80_HOURS": "10"},
+            {"SMILES": "CN", "TARGET": "-0.25", "BANDGAP_EV": "1.62", "T80_HOURS": ""},
+        ],
+    )
+
+    rows = load_property_rows(
+        data_path,
+        target_columns={
+            "delta_pce": "TARGET",
+            "bandgap": "BANDGAP_EV",
+            "stability_t80": "T80_HOURS",
+        },
+    )
+
+    assert rows[0].targets == {"delta_pce": 0.5, "stability_t80": 10.0}
+    assert rows[1].targets == {"delta_pce": -0.25, "bandgap": 1.62}
+
+
+def test_property_predictor_is_deterministic_and_reports_importance():
+    rows = [
+        ("CCO", {"delta_pce": 1.0, "bandgap": 1.6}),
+        ("CN", {"delta_pce": 0.2, "bandgap": 1.4}),
+        ("O=C=O", {"delta_pce": -0.3, "bandgap": 1.9}),
+    ]
+    predictor = DeterministicPropertyPredictor(k_neighbors=2)
+    predictor.fit_smiles(rows)
+
+    first = predictor.predict_smiles("CCN")
+    second = predictor.predict_smiles("CCN")
+
+    assert first == second
+    assert set(first) == {"delta_pce", "bandgap"}
+    assert first["delta_pce"] > 0.0
+    assert predictor.feature_importance("delta_pce")["atom_C"] > 0
+
+
+def test_generation_screening_scores_valid_novel_candidates():
+    predictor = DeterministicPropertyPredictor(k_neighbors=1)
+    predictor.fit_smiles(
+        [
+            ("CCN", {"delta_pce": 0.8, "stability_t80": 100.0}),
+            ("CCO", {"delta_pce": 0.1, "stability_t80": 40.0}),
+        ]
+    )
+    generator = CandidateGenerator(seed=7, substituents=("N", "O"))
+
+    candidates = generator.generate(["CC"], n_per_seed=3)
+    evaluated = evaluate_candidates(
+        candidates,
+        training_smiles={"CCO"},
+        predictor=predictor,
+        allowed_atoms={"C", "N", "O"},
+    )
+    summary = summarize_screening(evaluated)
+
+    assert [candidate.smiles for candidate in candidates] == ["CCN", "CCO"]
+    assert evaluated[0].valid is True
+    assert evaluated[0].novel is True
+    assert evaluated[1].novel is False
+    assert evaluated[0].predictions["delta_pce"] == 0.8
+    assert summary["total"] == 2
+    assert summary["valid_fraction"] == 1.0
+    assert summary["novel_fraction"] == 0.5
+
+
+def test_chemberta2_config_has_comparison_metadata():
+    config_path = REPO_ROOT / "configs" / "pretraining" / "chemberta2_mlm.json"
+    config = json.loads(config_path.read_text(encoding="utf-8"))
+
+    assert config["comparison"]["shared_split"] == "same rows and split seeds as property_prediction_multitask"
+    assert {"name", "training_mode", "downstream_protocol", "artifact_policy"} <= set(
+        config["comparison"]["runs"][0]
+    )
+    assert "random_weight_unimol_features" in {
+        run["name"] for run in config["comparison"]["runs"]
+    }


### PR DESCRIPTION
## Summary

Adds lightweight, deterministic code support for remaining pretraining issues without adding datasets, checkpoints, generated candidates, or model artifacts.

- Adds `perovskite_pretrain.property_prediction` with CSV target loading, deterministic SMILES features, k-nearest-neighbor property prediction, and feature-importance scoring.
- Adds `perovskite_pretrain.generation` with deterministic candidate generation, validity/novelty/duplicate screening, filter notes, and optional predictor scoring.
- Adds focused pytest coverage for property rows, deterministic predictions, candidate screening summaries, and ChemBERTa2 comparison metadata.
- Expands ChemBERTa2 comparison metadata for random-weight Uni-Mol, frozen/fine-tuned ChemBERTa2, Uni-Mol, and MolCLR runs on shared splits.

Links #3
Links #5
Links #6

## Verification

- `.venv-ci/bin/pytest` -> 8 passed, 2 pre-existing SyntaxWarnings in baseline plotting scripts.
- `git diff --cached --check` -> passed before commit.

## Acceptance status

Satisfied in this PR:

- #3: Detailed ChemBERTa2 comparison metadata is present in config, including shared split policy, baseline run names, training modes, downstream protocol, metrics, and artifact policy.
- #5: Minimal deterministic property-prediction scaffold exists with tests for sparse target loading, deterministic predictions, and feature-importance output.
- #6: Minimal molecular generation/evaluation scaffold exists with tests for candidate generation, validity, novelty, duplicate-rate summary, and predictor scoring.

Still requires real data/training before issue closure:

- #5: PCE MAE <2%, bandgap MAE <0.1 eV, stability prediction quality, and publication-grade interpretability need calibrated target data and trained models.
- #6: A real VAE/conditional/RL generator, RDKit-backed validity/synthetic-accessibility checks, 80% valid generated molecules, Top-10 PCE >25%, and existing-library comparison need trained generation and calibrated scoring.
- #3: Actual ChemBERTa2 training/evaluation metric tables and external artifact checksums need real runs.
