### PR TITLE
feat: add property prediction benchmark/report contract

### DIFF
--- a/configs/pretraining/property_prediction_multitask.json
+++ b/configs/pretraining/property_prediction_multitask.json
@@ -52,6 +52,12 @@
       3,
       4
     ],
+    "lightweight_report": {
+      "module": "perovskite_pretrain.property_prediction",
+      "entrypoint": "leave_one_out_benchmark",
+      "output_schema": "write_benchmark_report JSON",
+      "purpose": "CI-safe smoke benchmark and report contract before calibrated model training"
+    },
     "report": [
       "mean_metric",
       "std_metric",

--- a/docs/pretraining_workflows.md
+++ b/docs/pretraining_workflows.md
@@ -38,6 +38,14 @@ Config stub: `configs/pretraining/property_prediction_multitask.json`.
 
 Lightweight scaffold: `perovskite_pretrain.property_prediction` provides dependency-free CSV loading, deterministic SMILES features, a k-nearest-neighbor regressor, and simple feature-importance scores. This is for smoke tests, candidate screening, and schema validation only; it does not satisfy the trained MAE thresholds without calibrated data and model training.
 
+The same module now also defines a CI-safe benchmark/report contract:
+
+- `regression_metrics(actual, predicted)` computes MAE, RMSE, and R2 without extra dependencies.
+- `leave_one_out_benchmark(rows, acceptance_mae=...)` evaluates each labeled property with deterministic leave-one-out splits.
+- `write_benchmark_report(path, benchmarks, dataset_manifest=...)` writes a JSON report that can be archived with dataset source, license, split, and artifact metadata.
+
+Use the lightweight report to validate data wiring before training large models. Treat an acceptance flag as publication evidence only when the dataset manifest points to the real benchmark rows and the calibrated model configuration used for the reported run.
+
 Recommended evaluation sequence:
 
 1. Run DFT/KRFP baselines with the same split seeds.
@@ -55,6 +63,17 @@ Required report fields:
 | feature_set | DFT, KRFP, Uni-Mol, MolCLR, ChemBERTa2, or random-weight control. |
 | metric | MAE/RMSE/R2 with target units. |
 | artifact | Local path or external URI plus checksum for weights and outputs. |
+
+Minimum JSON report fields:
+
+| Field | Purpose |
+| --- | --- |
+| dataset_manifest.source | Dataset or benchmark source. |
+| dataset_manifest.license | Data license or access note. |
+| benchmarks.*.metrics.mae | Target-unit MAE for the evaluated split. |
+| benchmarks.*.acceptance_mae | Issue-defined target threshold, if available. |
+| benchmarks.*.acceptance_passed | Whether the reported MAE satisfies that threshold. |
+| benchmarks.*.top_features | Feature-importance smoke output for interpretability review. |
 
 ## Issue #6: Perovskite Molecular Generation
 

--- a/perovskite_pretrain/property_prediction.py
+++ b/perovskite_pretrain/property_prediction.py
@@ -9,9 +9,10 @@ metrics.
 from __future__ import annotations
 
 import csv
+import json
 import math
 import re
-from dataclasses import dataclass
+from dataclasses import asdict, dataclass
 from pathlib import Path
 from typing import Iterable, Mapping
 
@@ -30,6 +31,27 @@ class PropertyRow:
 
     smiles: str
     targets: dict[str, float]
+
+
+@dataclass(frozen=True)
+class RegressionMetrics:
+    """Regression metrics for one target on one evaluated split."""
+
+    n: int
+    mae: float
+    rmse: float
+    r2: float | None
+
+
+@dataclass(frozen=True)
+class TaskBenchmark:
+    """Benchmark summary for one property target."""
+
+    task: str
+    metrics: RegressionMetrics
+    acceptance_mae: float | None
+    acceptance_passed: bool | None
+    top_features: list[tuple[str, float]]
 
 
 def load_property_rows(
@@ -59,6 +81,90 @@ def load_property_rows(
                 rows.append(PropertyRow(smiles=smiles, targets=targets))
 
     return rows
+
+
+def regression_metrics(actual: Iterable[float], predicted: Iterable[float]) -> RegressionMetrics:
+    """Compute dependency-free regression metrics."""
+
+    actual_values = list(actual)
+    predicted_values = list(predicted)
+    if len(actual_values) != len(predicted_values):
+        raise ValueError("actual and predicted must have the same length")
+    if not actual_values:
+        raise ValueError("At least one prediction is required")
+
+    errors = [prediction - truth for truth, prediction in zip(actual_values, predicted_values, strict=True)]
+    mae = sum(abs(error) for error in errors) / len(errors)
+    rmse = math.sqrt(sum(error * error for error in errors) / len(errors))
+
+    mean_actual = sum(actual_values) / len(actual_values)
+    total_sum_squares = sum((truth - mean_actual) ** 2 for truth in actual_values)
+    if total_sum_squares == 0:
+        r2 = None
+    else:
+        residual_sum_squares = sum(error * error for error in errors)
+        r2 = 1.0 - (residual_sum_squares / total_sum_squares)
+
+    return RegressionMetrics(n=len(actual_values), mae=mae, rmse=rmse, r2=r2)
+
+
+def leave_one_out_benchmark(
+    rows: Iterable[PropertyRow],
+    k_neighbors: int = 3,
+    acceptance_mae: Mapping[str, float] | None = None,
+    top_n_features: int = 5,
+) -> dict[str, TaskBenchmark]:
+    """Evaluate the scaffold predictor with deterministic leave-one-out splits."""
+
+    row_list = list(rows)
+    if len(row_list) < 2:
+        raise ValueError("At least two labeled rows are required for leave-one-out evaluation")
+
+    task_names = sorted({task for row in row_list for task in row.targets})
+    thresholds = dict(acceptance_mae or {})
+    reports: dict[str, TaskBenchmark] = {}
+
+    for task in task_names:
+        actual: list[float] = []
+        predicted: list[float] = []
+        labeled_indexes = [index for index, row in enumerate(row_list) if task in row.targets]
+        if len(labeled_indexes) < 2:
+            continue
+
+        for held_out_index in labeled_indexes:
+            train_rows = [row for index, row in enumerate(row_list) if index != held_out_index]
+            predictor = DeterministicPropertyPredictor(k_neighbors=k_neighbors).fit(train_rows)
+            prediction = predictor.predict_smiles(row_list[held_out_index].smiles)
+            actual.append(row_list[held_out_index].targets[task])
+            predicted.append(prediction[task])
+
+        fitted_predictor = DeterministicPropertyPredictor(k_neighbors=k_neighbors).fit(row_list)
+        importance = list(fitted_predictor.feature_importance(task).items())[:top_n_features]
+        metrics = regression_metrics(actual, predicted)
+        threshold = thresholds.get(task)
+        reports[task] = TaskBenchmark(
+            task=task,
+            metrics=metrics,
+            acceptance_mae=threshold,
+            acceptance_passed=None if threshold is None else metrics.mae < threshold,
+            top_features=importance,
+        )
+
+    return reports
+
+
+def write_benchmark_report(
+    report_path: str | Path,
+    benchmarks: Mapping[str, TaskBenchmark],
+    dataset_manifest: Mapping[str, str] | None = None,
+) -> None:
+    """Write a portable JSON report for property-prediction benchmark runs."""
+
+    payload = {
+        "dataset_manifest": dict(dataset_manifest or {}),
+        "benchmarks": {task: asdict(report) for task, report in sorted(benchmarks.items())},
+    }
+    Path(report_path).write_text(json.dumps(payload, indent=2, sort_keys=True) + "\n", encoding="utf-8")
 
 
 def smiles_features(smiles: str) -> dict[str, float]:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -2,3 +2,9 @@
 testpaths = ["tests"]
 python_files = ["test_*.py"]
 pythonpath = ["."]
+
+[dependency-groups]
+dev = [
+    "pytest>=9.0.3",
+    "ruff>=0.15.16",
+]

--- a/tests/test_deterministic_skeletons.py
+++ b/tests/test_deterministic_skeletons.py
@@ -9,7 +9,10 @@ from perovskite_pretrain.generation import (
 )
 from perovskite_pretrain.property_prediction import (
     DeterministicPropertyPredictor,
+    leave_one_out_benchmark,
     load_property_rows,
+    regression_metrics,
+    write_benchmark_report,
 )
 
 
@@ -21,6 +24,19 @@ def write_csv(path, rows):
         writer = csv.DictWriter(handle, fieldnames=rows[0].keys())
         writer.writeheader()
         writer.writerows(rows)
+    return path
+
+
+def write_property_fixture(path):
+    return write_csv(
+        path,
+        [
+            {"SMILES": "CCO", "TARGET": "1.0", "BANDGAP_EV": "1.5", "T80_HOURS": "40"},
+            {"SMILES": "CCN", "TARGET": "1.2", "BANDGAP_EV": "1.6", "T80_HOURS": "50"},
+            {"SMILES": "CCC", "TARGET": "0.8", "BANDGAP_EV": "1.4", "T80_HOURS": "35"},
+            {"SMILES": "COC", "TARGET": "0.5", "BANDGAP_EV": "1.8", "T80_HOURS": "65"},
+        ],
+    )
 
 
 def test_property_rows_load_only_available_targets(tmp_path):
@@ -62,6 +78,37 @@ def test_property_predictor_is_deterministic_and_reports_importance():
     assert set(first) == {"delta_pce", "bandgap"}
     assert first["delta_pce"] > 0.0
     assert predictor.feature_importance("delta_pce")["atom_C"] > 0
+
+
+def test_property_benchmark_reports_metrics_and_acceptance(tmp_path):
+    rows = load_property_rows(write_property_fixture(tmp_path / "properties.csv"))
+
+    metrics = regression_metrics([1.0, 2.0, 3.0], [1.2, 2.2, 2.6])
+    assert metrics.n == 3
+    assert round(metrics.mae, 6) == round((0.2 + 0.2 + 0.4) / 3, 6)
+    assert metrics.rmse > metrics.mae
+    assert metrics.r2 is not None
+
+    benchmarks = leave_one_out_benchmark(
+        rows,
+        k_neighbors=1,
+        acceptance_mae={"delta_pce": 10.0, "bandgap": 10.0},
+        top_n_features=3,
+    )
+    assert {"delta_pce", "bandgap"} <= set(benchmarks)
+    assert benchmarks["delta_pce"].metrics.n == 4
+    assert benchmarks["delta_pce"].acceptance_passed is True
+    assert benchmarks["delta_pce"].top_features
+
+    report_path = tmp_path / "benchmark-report.json"
+    write_benchmark_report(
+        report_path,
+        benchmarks,
+        dataset_manifest={"source": "unit-test fixture", "license": "synthetic"},
+    )
+    report = json.loads(report_path.read_text(encoding="utf-8"))
+    assert report["dataset_manifest"]["source"] == "unit-test fixture"
+    assert report["benchmarks"]["bandgap"]["metrics"]["n"] == 4
 
 
 def test_generation_screening_scores_valid_novel_candidates():

--- a/uv.lock
+++ b/uv.lock
@@ -1,0 +1,97 @@
+version = 1
+revision = 3
+requires-python = ">=3.13"
+
+[manifest]
+
+[manifest.dependency-groups]
+dev = [
+    { name = "pytest", specifier = ">=9.0.3" },
+    { name = "ruff", specifier = ">=0.15.16" },
+]
+
+[[package]]
+name = "colorama"
+version = "0.4.6"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "iniconfig"
+version = "2.3.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/72/34/14ca021ce8e5dfedc35312d08ba8bf51fdd999c576889fc2c24cb97f4f10/iniconfig-2.3.0.tar.gz", hash = "sha256:c76315c77db068650d49c5b56314774a7804df16fee4402c1f19d6d15d8c4730", size = 20503, upload-time = "2025-10-18T21:55:43.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/cb/b1/3846dd7f199d53cb17f49cba7e651e9ce294d8497c8c150530ed11865bb8/iniconfig-2.3.0-py3-none-any.whl", hash = "sha256:f631c04d2c48c52b84d0d0549c99ff3859c98df65b3101406327ecc7d53fbf12", size = 7484, upload-time = "2025-10-18T21:55:41.639Z" },
+]
+
+[[package]]
+name = "packaging"
+version = "26.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/d7/f1/e7a6dd94a8d4a5626c03e4e99c87f241ba9e350cd9e6d75123f992427270/packaging-26.2.tar.gz", hash = "sha256:ff452ff5a3e828ce110190feff1178bb1f2ea2281fa2075aadb987c2fb221661", size = 228134, upload-time = "2026-04-24T20:15:23.917Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/df/b2/87e62e8c3e2f4b32e5fe99e0b86d576da1312593b39f47d8ceef365e95ed/packaging-26.2-py3-none-any.whl", hash = "sha256:5fc45236b9446107ff2415ce77c807cee2862cb6fac22b8a73826d0693b0980e", size = 100195, upload-time = "2026-04-24T20:15:22.081Z" },
+]
+
+[[package]]
+name = "pluggy"
+version = "1.6.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/f9/e2/3e91f31a7d2b083fe6ef3fa267035b518369d9511ffab804f839851d2779/pluggy-1.6.0.tar.gz", hash = "sha256:7dcc130b76258d33b90f61b658791dede3486c3e6bfb003ee5c9bfb396dd22f3", size = 69412, upload-time = "2025-05-15T12:30:07.975Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/54/20/4d324d65cc6d9205fabedc306948156824eb9f0ee1633355a8f7ec5c66bf/pluggy-1.6.0-py3-none-any.whl", hash = "sha256:e920276dd6813095e9377c0bc5566d94c932c33b27a3e3945d8389c374dd4746", size = 20538, upload-time = "2025-05-15T12:30:06.134Z" },
+]
+
+[[package]]
+name = "pygments"
+version = "2.20.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+]
+
+[[package]]
+name = "pytest"
+version = "9.0.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "colorama", marker = "sys_platform == 'win32'" },
+    { name = "iniconfig" },
+    { name = "packaging" },
+    { name = "pluggy" },
+    { name = "pygments" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "ruff"
+version = "0.15.16"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/a6/bd/5f7ec371001337d8fa61701c186ff8b613ecac1651848c5950f4c4d5f2e9/ruff-0.15.16.tar.gz", hash = "sha256:d05e78d38c78caf020b03789e25106c93017db5a0cb6e2819885018c61343b78", size = 4714267, upload-time = "2026-06-04T16:33:09.974Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/0c/42/53ef1c3953f157956db9bf7861e3bc50b9b887ce93300aa48cdba8336fe6/ruff-0.15.16-py3-none-linux_armv6l.whl", hash = "sha256:6ac3c0b3969cc6cf6b158c4e2f8f682acb58e7d700d8a44b65ecdc72d66ab0b2", size = 10709025, upload-time = "2026-06-04T16:32:51.935Z" },
+    { url = "https://files.pythonhosted.org/packages/93/9a/a79159346f19134a956607754e57d8d128f7a4c00f4ad2f7514d224c172c/ruff-0.15.16-py3-none-macosx_10_12_x86_64.whl", hash = "sha256:197c207ed75ffba54a0dec23db4aa939a27a3053073e085e0042433cbdc58e4a", size = 11063550, upload-time = "2026-06-04T16:32:42.24Z" },
+    { url = "https://files.pythonhosted.org/packages/bc/72/3ce2ac000a5299ec238e01f51397b3b653c93b077d9b1bfe8715bb895f20/ruff-0.15.16-py3-none-macosx_11_0_arm64.whl", hash = "sha256:3a39fec45ab316cc23e7558f23fea4a70403ddb5648ea9a4a3854a16973d0071", size = 10421345, upload-time = "2026-06-04T16:32:37.251Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/c2/cc7fad3ec9169373f5b6a18f1917b91080feec40c3f9658334a1d28e2f03/ruff-0.15.16-py3-none-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ba93191d79003116b95128c9d306e045200fdbd0bccb782b110f3cd1d4abc5cf", size = 10757217, upload-time = "2026-06-04T16:32:54.722Z" },
+    { url = "https://files.pythonhosted.org/packages/69/d2/3474009eaa0a65b31fa7152a2fad5e2f050c640ceb1e6b02ee6922e94c82/ruff-0.15.16-py3-none-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c6ee4b90520630120ef032aa5cc10db483852dff950e78b1d717e2993a61ac8d", size = 10507035, upload-time = "2026-06-04T16:33:05.343Z" },
+    { url = "https://files.pythonhosted.org/packages/ca/81/b7ae6ccbd11f0c8dc3d5d67fc4be9b57ff57ca86ba56152021378e1277f2/ruff-0.15.16-py3-none-manylinux_2_17_i686.manylinux2014_i686.whl", hash = "sha256:4e4215bc938bc3c8215c1472c1aa437e310fee20cd427335fec9d7e609563628", size = 11255291, upload-time = "2026-06-04T16:32:49.49Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/e1/46e526f1a7cc90857ce6ddf25fbb77eb6568651ac38d71b033af07076dd5/ruff-0.15.16-py3-none-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:7c8d26be963b090f10e29abc8b3e74a2a321f6fa34e02424e30b5af89350ecbb", size = 12124922, upload-time = "2026-06-04T16:33:07.821Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/da/5c791b088b596b24d0deb967fa28ae02ad751a140c0b9ea81c5ab915d6c0/ruff-0.15.16-py3-none-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:f198cf4123602a2280ed46c307bcbafe41758d6fee5b456b6b6058ca1514b3b4", size = 11332186, upload-time = "2026-06-04T16:33:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/72/11/5da87abe20047c8962361473923ebb2f62b595250126aadfad8c20649c1e/ruff-0.15.16-py3-none-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:bb27515fa6240fb586ae82b901a59e67d24acff86f2190b433dc542fe0435aeb", size = 11373541, upload-time = "2026-06-04T16:32:47.007Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/2a/8554754c23a854ae3fd6b507e36ad61ddb121e298c6d5d617dec94ed0f14/ruff-0.15.16-py3-none-manylinux_2_31_riscv64.whl", hash = "sha256:a267c46ba1593fc26b8eecbea050b39d40c0b6bb7781ee11c90a02cd10032951", size = 11353014, upload-time = "2026-06-04T16:32:34.795Z" },
+    { url = "https://files.pythonhosted.org/packages/62/25/62ea41529ec89f742ea3fed9cb1059c72877ec7cf9b9e99ac9cf3294d1d9/ruff-0.15.16-py3-none-musllinux_1_2_aarch64.whl", hash = "sha256:528c68f39a91498a8d50e91ff5985df3d105782bab49cc378e73ac26bff083e8", size = 10737467, upload-time = "2026-06-04T16:32:26.348Z" },
+    { url = "https://files.pythonhosted.org/packages/90/17/334d3ad9de4d40f9dd58fdd09e35ce64553bb501e2f19a839e2fb6be14fc/ruff-0.15.16-py3-none-musllinux_1_2_armv7l.whl", hash = "sha256:7ed55c58950df60589a9a7a5d2f8fa5f54ebd287163be805adfe6ee95a9de123", size = 10521910, upload-time = "2026-06-04T16:32:32.54Z" },
+    { url = "https://files.pythonhosted.org/packages/4d/bd/3ac7c6ae77a885c1004b3dda2446ea401768d24f851c14b4ad4b24f6639c/ruff-0.15.16-py3-none-musllinux_1_2_i686.whl", hash = "sha256:d482feaf51512b50f9790ceb417a56a61dd1e9d9bf967662b9ed27c01b34f53a", size = 10979190, upload-time = "2026-06-04T16:32:57.492Z" },
+    { url = "https://files.pythonhosted.org/packages/33/d7/609546e6a413c3f216fbf2a50c928f97c80939154f6a0503114094a86191/ruff-0.15.16-py3-none-musllinux_1_2_x86_64.whl", hash = "sha256:1e15bc8c94513dae2a40cc9ef07c94fdd4ecc9e29dabebeebe170f952322c9e3", size = 11477014, upload-time = "2026-06-04T16:32:44.687Z" },
+    { url = "https://files.pythonhosted.org/packages/74/0d/f2cd247ad32633a5c36e97141a2c21b11c6279f7957bc2ff360b1e08fddd/ruff-0.15.16-py3-none-win32.whl", hash = "sha256:580378f7bd4aa25f72e74aa54948a9622f142b1e509521dd10902e886681cc1e", size = 10735541, upload-time = "2026-06-04T16:32:30.145Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/9e/02e845ef151b1dee585e55c4739f8e1734ae1d9f1221dff65761c162208b/ruff-0.15.16-py3-none-win_amd64.whl", hash = "sha256:408256017284eddf98fff77b29aa4fb30f586042d535b2d9befc6512f400aaec", size = 11843403, upload-time = "2026-06-04T16:32:39.76Z" },
+    { url = "https://files.pythonhosted.org/packages/15/19/016553f86f207450aebebc2b2b5088d086b901cc8186c02ac4284db3bd88/ruff-0.15.16-py3-none-win_arm64.whl", hash = "sha256:8cd61783afb39638a7133ef0d2dfb1e91277593962f81b5a8423eb0b888a6121", size = 11134555, upload-time = "2026-06-04T16:33:00.136Z" },
+]


### PR DESCRIPTION
## Summary

Adds a CI-safe benchmark and reporting contract for property prediction (issue #5).

## Changes

- regression_metrics(): Computes MAE, RMSE, and R2 without external dependencies
- leave_one_out_benchmark(): Evaluates the deterministic k-NN predictor with leave-one-out splits
- write_benchmark_report(): Writes portable JSON reports with dataset metadata
- Config: Added lightweight_report entry to property_prediction_multitask.json
- Documentation: Updated pretraining_workflows.md with benchmark contract specification
- Tests: Added comprehensive test coverage for the benchmark/report workflow

## Acceptance Criteria Status

This PR implements the benchmark/report infrastructure, not the trained model itself. The acceptance thresholds from issue #5 are:

PCE prediction <2% MAE: Infrastructure ready, awaiting calibrated model training
Bandgap prediction <0.1 eV MAE: Infrastructure ready, awaiting calibrated model training
Stability prediction: Infrastructure ready, awaiting calibrated model training
Model interpretability: Feature importance reporting included

## Why issue #5 should NOT close yet

The acceptance criteria require real MAE metrics <2% for PCE and <0.1 eV for bandgap. These thresholds can only be met with a calibrated model trained on real benchmark data, a published dataset manifest pointing to that data, and actual evaluation runs with traceable artifact checksums.

This PR provides the scaffold to generate and report those metrics once the model is trained.

## Tests

All 5 tests pass, including the new benchmark/report test.

Refs #5 (does NOT close)